### PR TITLE
Move game prize calculation to backend

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -15,6 +15,10 @@
      let gameStarted = false;
      let backendGameData = null;
      
+     // Game settings that need to be accessible globally
+     let gameSpeed = 3000; // Default fallback
+     let allowedPatterns = [];
+     
      // Define initializeGame function before using it
      async function initializeGame() {
          try {
@@ -191,12 +195,10 @@
          } catch(e) {}
 
          // Game settings
-         let gameSpeed = 3000;
          const audioBase = '/wp-content/uploads/2025/08';
 
          let interval = null;
          let gamePaused = false;
-         let allowedPatterns = [];
          let numbers = [];
          let currentIndex = 0;
          let calledCount = 0;

--- a/bingo.js
+++ b/bingo.js
@@ -13,7 +13,6 @@
      let gameInitialized = false;
      let cachedRuntime = null;
      let gameStarted = false;
-     let backendGameData = null;
      
      // Game settings that need to be accessible globally
      let gameSpeed = 3000; // Default fallback
@@ -68,14 +67,6 @@
              // Populate game variables from backend response
              gamePrize = Number(data.gamePrize || 0);
              canPlay = Boolean(data.canPlay);
-             
-             // Store backend data for game start API call
-             backendGameData = data.gameData || {
-                 systemCommission: 0,
-                 retailorCut: 0,
-                 gross: 0,
-                 numberOfPlayers: 0
-             };
              
              // Cache runtime data for instant play button response
              if (runtimePayload && runtimePayload.success) {
@@ -560,10 +551,8 @@
                  const url = window.ajaxurl || '/wp-admin/admin-ajax.php';
                  const form = new FormData();
                  form.append('action', 'bingo_start_game');
-                 form.append('systemCut', String(backendGameData.systemCommission));
-                 form.append('retailorCut', String(backendGameData.retailorCut));
-                 form.append('gross', String(backendGameData.gross));
-                 form.append('numberOfPlayers', String(backendGameData.numberOfPlayers));
+                 form.append('activeCards', JSON.stringify(activeCards));
+                 form.append('cartelaPrice', String(cartelaPrice));
                  form.append('_', String(Date.now()));
                  
                  fetch(url, { 

--- a/bingo.js
+++ b/bingo.js
@@ -1,11 +1,31 @@
  (function($){
      $(document).ready(function(){
+         // Only run on game page - check for game-specific elements
+         const $gamePrizeEl = $('#GamePrize > h2');
+         const $betEl = $('#bet > h2');
+         const $playBtn = $('#play_pause_game a.elementor-button');
+         
+         // If game elements don't exist, this isn't the game page - exit early
+         if (!$gamePrizeEl.length && !$betEl.length && !$playBtn.length) {
+             return;
+         }
+         
          const ss = window.sessionStorage;
          const activeCards = JSON.parse(ss.getItem('activeCards') || '[]');
          const activeCartdsBinogoNumber = JSON.parse(ss.getItem('activeCartdsBinogoNumber') || '[]');
          const cartelaPrice = Number(ss.getItem('cartelaPrice') || '0');
          const pattern = ss.getItem('pattern') || '1';
          const requiredLines = parseInt(pattern, 10) || 1; // Default to 1 line if pattern is invalid
+        
+         // Additional validation - ensure we have the required session data
+         if (!activeCards.length || !activeCartdsBinogoNumber.length || !cartelaPrice) {
+             console.error('Missing required session data for game initialization');
+             if ($playBtn.length) {
+                 $playBtn.prop('disabled', true);
+                 $playBtn.find('.elementor-button-text').text('Invalid Game Data');
+             }
+             return;
+         }
         
          // Game state variables to be populated from backend
          let gamePrize = 0;
@@ -19,14 +39,12 @@
          // Cache runtime data to avoid repeated API calls
          let cachedRuntime = null;
          let gameStarted = false;
-
-         const $gamePrizeEl = $('#GamePrize > h2');
-         const $betEl = $('#bet > h2');
-         const $playBtn = $('#play_pause_game a.elementor-button');
          
          // Initially disable play button and show loading state
-         $playBtn.prop('disabled', true);
-         $playBtn.find('.elementor-button-text').text('Loading...');
+         if ($playBtn.length) {
+             $playBtn.prop('disabled', true);
+             $playBtn.find('.elementor-button-text').text('Loading...');
+         }
          
          // Initialize game by sending data to backend
          initializeGame();
@@ -104,13 +122,15 @@
                  if ($betEl.length) { $betEl.text(cartelaPrice); }
                  
                  // Enable/disable play button based on canPlay
-                 $playBtn.prop('disabled', false);
-                 if (canPlay) {
-                     $playBtn.find('.elementor-button-text').text('Play');
-                     $playBtn.removeClass('disabled-btn');
-                 } else {
-                     $playBtn.find('.elementor-button-text').text('Insufficient Balance');
-                     $playBtn.addClass('disabled-btn');
+                 if ($playBtn.length) {
+                     $playBtn.prop('disabled', false);
+                     if (canPlay) {
+                         $playBtn.find('.elementor-button-text').text('Play');
+                         $playBtn.removeClass('disabled-btn');
+                     } else {
+                         $playBtn.find('.elementor-button-text').text('Insufficient Balance');
+                         $playBtn.addClass('disabled-btn');
+                     }
                  }
                  
                  console.log('Game initialized:', {

--- a/bingo.php
+++ b/bingo.php
@@ -25,10 +25,12 @@ add_action('wp_ajax_bingo_get_runtime', function(){
     $cartelas_balance = intval(get_field('cartelas_balance', 'user_' . $user_id));
     $game_speed = intval(get_field('game_speed', 'user_' . $user_id));
     $checking_pattern = get_field('checking_pattern', 'user_' . $user_id);
+    $game_sound = get_field('game_sound', 'user_' . $user_id);
 
     // Sensible defaults if empty
     if ($game_speed <= 0) { $game_speed = 3; }
     if ($cartelas_balance < 0) { $cartelas_balance = 0; }
+    if (empty($game_sound)) { $game_sound = 'Default'; }
 
     // Normalize checking_pattern to array of strings
     if (!is_array($checking_pattern)) { $checking_pattern = $checking_pattern ? [$checking_pattern] : []; }
@@ -36,7 +38,8 @@ add_action('wp_ajax_bingo_get_runtime', function(){
     wp_send_json_success([
         'cartelas_balance' => $cartelas_balance,
         'game_speed' => $game_speed,
-        'checking_pattern' => array_values(array_filter(array_map('strval', $checking_pattern)))
+        'checking_pattern' => array_values(array_filter(array_map('strval', $checking_pattern))),
+        'game_sound' => $game_sound
     ]);
 });
 

--- a/bingo.php
+++ b/bingo.php
@@ -90,15 +90,17 @@ add_action('wp_ajax_bingo_init_game', function(){
     $cartelas_balance = intval(get_field('cartelas_balance', 'user_' . $user_id)) ?: 0;
     $can_play = $cartelas_balance >= $system_commission;
     
-    // Return calculated values to frontend
+    // Return only essential data to frontend
     wp_send_json_success([
         'gamePrize' => $game_prize,
         'canPlay' => $can_play,
-        'systemCommission' => $system_commission,
-        'retailorCut' => $retailor_cut,
-        'gross' => $gross,
-        'numberOfPlayers' => $number_of_players,
-        'currentBalance' => $cartelas_balance
+        // Backend data for game start API call
+        'gameData' => [
+            'systemCommission' => $system_commission,
+            'retailorCut' => $retailor_cut,
+            'gross' => $gross,
+            'numberOfPlayers' => $number_of_players
+        ]
     ]);
 });
 

--- a/game-setup.js
+++ b/game-setup.js
@@ -84,58 +84,32 @@ document.addEventListener('DOMContentLoaded', function () {
         const selectedIds = checkedInputs.map(input => parseInt(String(input.value), 10)).filter(n => !Number.isNaN(n));
         const activeCartdsBinogoNumber = bingoCards.filter(card => selectedIds.includes(parseInt(String(card.id), 10)));
 
-        // Counts and pricing
-        const playersCount = activeCards.length;
+        // Get price and pattern values
         const priceInput = document.getElementById('cartelaPrice');
         const priceValue = priceInput ? parseFloat(String(priceInput.value || '').trim()) : NaN;
         
-        // Get pattern value
         const patternInput = document.getElementById('pattern');
         const patternValue = patternInput ? parseFloat(String(patternInput.value || '').trim()) : NaN;
 
-        const gross = Number.isFinite(priceValue) ? playersCount * priceValue : 0;
-
-        const playerThreshold = 4;
-        const retailorCutPercentage = 0.20;
-        const systemCutPercentage = 0.20;
-
-        const retailorCut = playersCount >= playerThreshold ? gross * retailorCutPercentage : 0;
-        const systemCut = playersCount >= playerThreshold ? retailorCut * systemCutPercentage : 0;
-
-        const GamePrize = gross - retailorCut;
-        const reduceCartelaPrice = playersCount >= playerThreshold;
-
-        if (playersCount < 2) {
+        // Basic validation - minimum 2 players
+        if (activeCards.length < 2) {
           alert('Not enough players. You must select at least 2.');
           return;
         }
 
-        // Persist to sessionStorage
+        // Only store essential data in sessionStorage
         try {
           sessionStorage.setItem('activeCartdsBinogoNumber', JSON.stringify(activeCartdsBinogoNumber));
           sessionStorage.setItem('activeCards', JSON.stringify(activeCards));
-          sessionStorage.setItem('playersCount', String(playersCount));
-          sessionStorage.setItem('gross', String(gross));
           sessionStorage.setItem('cartelaPrice', String(Number.isFinite(priceValue) ? priceValue : 0));
-          sessionStorage.setItem('pattern', patternValue);
-          sessionStorage.setItem('GamePrize', String(GamePrize));
-          sessionStorage.setItem('systemCut', String(systemCut));
-          sessionStorage.setItem('retailorCut', String(retailorCut));
-          sessionStorage.setItem('reduceCartelaPrice', JSON.stringify(reduceCartelaPrice));
+          sessionStorage.setItem('pattern', String(Number.isFinite(patternValue) ? patternValue : 1));
 
-          const sessionSnapshot = {
-            playersCount: Number(sessionStorage.getItem('playersCount') || '0'),
-            gross: Number(sessionStorage.getItem('gross') || '0'),
-            cartelaPrice: Number(sessionStorage.getItem('cartelaPrice') || '0'),
-            pattern: sessionStorage.getItem('pattern') || '',
-            retailorCut: Number(sessionStorage.getItem('retailorCut') || '0'),
-            systemCut: Number(sessionStorage.getItem('systemCut') || '0'),
-            GamePrize: Number(sessionStorage.getItem('GamePrize') || '0'),
-            reduceCartelaPrice: JSON.parse(sessionStorage.getItem('reduceCartelaPrice') || 'false'),
-            activeCartdsBinogoNumber: JSON.parse(sessionStorage.getItem('activeCartdsBinogoNumber') || '[]'),
-            activeCards: JSON.parse(sessionStorage.getItem('activeCards') || '[]')
-          };
-          console.log('Stored sessionStorage values:', sessionSnapshot);
+          console.log('Stored essential sessionStorage values:', {
+            activeCards: activeCards,
+            cartelaPrice: Number.isFinite(priceValue) ? priceValue : 0,
+            pattern: Number.isFinite(patternValue) ? patternValue : 1,
+            activeCartdsBinogoNumber: activeCartdsBinogoNumber
+          });
           // Navigate to game page after saving
           window.location.href = '/game';
         } catch (e) {


### PR DESCRIPTION
Refactor game setup to move all sensitive economic calculations and balance validation to the backend for improved security.

This change ensures that `gamePrize`, `retailorCut`, `systemCommission`, and `gross` are calculated server-side, preventing client-side manipulation. It also introduces a pre-game initialization step where the backend validates the user's balance before allowing the game to start, disabling the play button and informing the user if funds are insufficient.

---
<a href="https://cursor.com/background-agent?bcId=bc-881a5d70-16a0-4237-ab17-d0bc06405dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-881a5d70-16a0-4237-ab17-d0bc06405dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

